### PR TITLE
update to macroid 2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
-android.Plugin.androidBuild
-platformTarget in Android := "android-23"
+enablePlugins(AndroidApp)
+platformTarget in Android := "android-25"
 
 name := "macroid-akka-pingpong"
 
-scalaVersion := "2.11.4"
+scalaVersion := "2.11.8"
 javacOptions ++= Seq("-target", "1.7", "-source", "1.7") // so we can build with java8
 
 // a shortcut
@@ -14,17 +14,11 @@ resolvers ++= Seq(
   "jcenter" at "http://jcenter.bintray.com"
 )
 
-// add linter
-scalacOptions in (Compile, compile) ++=
-  (dependencyClasspath in Compile).value.files.map("-P:wartremover:cp:" + _.toURI.toURL) ++
-  Seq("-P:wartremover:traverser:macroid.warts.CheckUi")
-
 libraryDependencies ++= Seq(
-  aar("org.macroid" %% "macroid" % "2.0.0-M4"),
-  "com.android.support" % "support-v4" % "22.1.1",
-  "org.macroid" %% "macroid-akka" % "2.0.0-M4",
-  "com.typesafe.akka" %% "akka-actor" % "2.3.6",
-  compilerPlugin("org.brianmckenna" %% "wartremover" % "0.11")
+  aar("org.macroid" %% "macroid" % "2.0"),
+  "com.android.support" % "support-v4" % "25.1.0",
+  "org.macroid" %% "macroid-akka" % "2.0",
+  "com.typesafe.akka" %% "akka-actor" % "2.3.16"
 )
 
 proguardScala in Android := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7-RC3
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.3.6")
+addSbtPlugin("org.scala-android" % "sbt-android" % "1.7.2")

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="23"/>
+        android:targetSdkVersion="25"/>
 
     <application
         android:icon="@drawable/android:star_big_on"

--- a/src/main/scala/com/example/pingpong/MainActivity.scala
+++ b/src/main/scala/com/example/pingpong/MainActivity.scala
@@ -10,8 +10,10 @@ import macroid._
 import macroid.FullDsl._
 import macroid.akka.AkkaActivity
 
+object Id extends IdGenerator(start = 1000)
+
 /** The main activity */
-class MainActivity extends FragmentActivity with Contexts[FragmentActivity] with IdGeneration with AkkaActivity {
+class MainActivity extends FragmentActivity with Contexts[FragmentActivity] with AkkaActivity {
   // name of our actor system
   val actorSystemName = "pingpong"
 
@@ -31,11 +33,11 @@ class MainActivity extends FragmentActivity with Contexts[FragmentActivity] with
     // include the two fragments
     val view = l[LinearLayout](
       // we pass a name for the actor, and id+tag for the fragment
-      f[RacketFragment].pass("name" → "ping").framed(Id.ping, Tag.ping) <~ lps,
-      f[RacketFragment].pass("name" → "pong").framed(Id.pong, Tag.pong) <~ lps
+      f[RacketFragment].pass(Bundles.bundle("name" -> "ping")).framed(Id.ping, Tag.ping) <~ lps,
+      f[RacketFragment].pass(Bundles.bundle("name" -> "pong")).framed(Id.pong, Tag.pong) <~ lps
     ) <~ vertical
 
-    setContentView(getUi(view))
+    setContentView(Ui.get(view))
   }
 
   override def onStart() = {

--- a/src/main/scala/com/example/pingpong/RacketFragment.scala
+++ b/src/main/scala/com/example/pingpong/RacketFragment.scala
@@ -16,7 +16,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 /** Styles for our widgets */
 object Styles {
   // how racket looks
-  def racket(implicit appCtx: AppContext) =
+  def racket(implicit appCtx: ContextWrapper) =
     hide + disable +
     text("SMASH") +
     TextTweaks.large +
@@ -59,7 +59,7 @@ class RacketFragment extends AkkaFragment with Contexts[AkkaFragment] {
     // tell the actor to smash
     Ui(actor.foreach(_ ! RacketActor.Smash))
 
-  override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle) = getUi {
+  override def onCreateView(inflater: LayoutInflater, container: ViewGroup, savedInstanceState: Bundle) = Ui.get {
     l[FrameLayout](
       w[Button] <~ wire(racket) <~ Styles.racket <~ On.click(smash)
     )


### PR DESCRIPTION
I was getting build errors with macroid-akka-pingpong from master, so I updated all dependencies to their latest versions, and I can now build it and deploy it in the emulator.

Changes:
 * `IdGeneration` appears to be gone, had to use an `IdGenerator` instead
 * `pass` macro is broken: https://github.com/47deg/macroid/issues/89, had to use `Bundles.bundle` macro instead
 * `Ui.get` instead of `getUi`
 * `ContextWrapper` instead of `AppContext`
  * wartRemover appears to be [gone](https://github.com/47deg/macroid/commit/62915d0ff44f06d58c3a63768202b197b48fa0da)

Updated versions:
 * Scala: 2.11.4 -> 2.11.8
 * macroid: 2.0.0-M4 -> 2.0
 * sbt:  0.13.7-RC3 -> 0.13.13
 * com.hanhuy.sbt:android-sdk-plugin:1.3.6 -> org.scala-android:sbt-android:1.7.2
 * akka-actor: 2.3.6 -> 2.3.16 (updating to 2.4.16 doesn't work)
 * android build SDK: 23 -> 25